### PR TITLE
vuetifyを組み込んだ

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   },
   "dependencies": {
     "marked": "^0.4.0",
-    "vue": "^2.5.11"
+    "vue": "^2.5.11",
+    "vuetify": "^1.1.1"
   },
   "browserslist": [
     "> 1%",

--- a/src/app/components/pages/Home.vue
+++ b/src/app/components/pages/Home.vue
@@ -1,26 +1,50 @@
 <template>
-  <div id="home">
-    <h1>{{ msg }}</h1>
-    <button @click="googleLogin">Google アカウントでログイン</button>
-  </div>
+  <section id="home">
+    <v-parallax src="https://cdn.vuetifyjs.com/images/parallax/material.jpg" :height="windowHeight">
+      <v-layout
+          column
+          align-center
+          justify-center
+          class="white--text"
+        >
+        <img src="../../assets/logo.png">
+        <h1 class="white--text ma-3 display-1 text-xs-center">{{ msg }}</h1>
+        <v-btn large light color="light-blue" @click.native="googleLogin" class="white--text" :loading="isLoading" :disabled="isLoading">
+          <v-icon dark left>fab fa-google</v-icon>
+          Google アカウントでログイン
+        </v-btn>
+      </v-layout>
+    </v-parallax>
+  </section>
 </template>
 
 <script>
 export default {
   name: 'home',
+  props: [
+    'isLoading'
+  ],
   data() {
     return {
-      msg: 'Welcome to MyMarkdown'
+      msg: 'Welcome to MyMarkdown',
+      windowHeight: 0
     }
   },
   methods: {
     googleLogin: function() {
+      this.isLoading = true;
       firebase.auth().signInWithRedirect(new firebase.auth.GoogleAuthProvider());
     }
+  },
+  beforeMount: function() {
+    this.windowHeight = window.innerHeight;
   }
 }
 </script>
 
 <style lang="scss" scoped>
+#home {
+  height: 100%;
+}
 </style>
 

--- a/src/app/entry/app.js
+++ b/src/app/entry/app.js
@@ -1,5 +1,10 @@
 import Vue from 'vue'
+import Vuetify from 'vuetify'
 import App from './component/app.component.vue';
+
+Vue.use(Vuetify)
+
+import 'vuetify/dist/vuetify.min.css' // Ensure you are using css-loader
 
 export function createApp() {
   const app = new Vue({

--- a/src/app/entry/component/app.component.vue
+++ b/src/app/entry/component/app.component.vue
@@ -1,7 +1,11 @@
 <template>
   <div id="app">
-    <Home v-if="!isLogin"></Home>
-    <Editor v-if="isLogin" :user="userData"></Editor>
+    <v-app>
+      <v-content>
+        <Home v-if="!isLogin" :is-loading="isLoading"></Home>
+        <Editor v-if="isLogin" :user="userData"></Editor>
+      </v-content>
+    </v-app>
   </div>
 </template>
 
@@ -18,10 +22,12 @@ export default {
   data () {
     return {
       isLogin: false,
-      userData: null
+      userData: null,
+      isLoading: false
     }
   },
   created: function() {
+    this.isLoading = true;
     firebase.auth().onAuthStateChanged(user => {
       console.log(user);
       if (user) {
@@ -31,10 +37,14 @@ export default {
         this.isLogin = false;
         this.userData = null;
       }
+      this.isLoading = false;
     });
   }
 }
 </script>
 
 <style lang="scss">
+body {
+  height: 100%;
+}
 </style>

--- a/src/app/templates/index.html
+++ b/src/app/templates/index.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>mymarkdown</title>
+    <link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons' rel="stylesheet">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
   </head>
   <body>
     <div id="app"></div>

--- a/src/app/templates/index.html
+++ b/src/app/templates/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>mymarkdown</title>
     <link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons' rel="stylesheet">
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">

--- a/yarn.lock
+++ b/yarn.lock
@@ -5377,6 +5377,10 @@ vue@^2.5.11:
   version "2.5.16"
   resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.16.tgz#07edb75e8412aaeed871ebafa99f4672584a0085"
 
+vuetify@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-1.1.1.tgz#8d8f64306a45aaf862487addae8decf082dac0a3"
+
 watchpack@^1.4.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"


### PR DESCRIPTION
## 実装内容

Vuetifyを導入して`Home.vue`のレイアウトを整えてみた

### 実装メモ

#### 1. Vuetifyのインストール

```sh
> yarn add vuetify
```

#### 2. 初期設定

```javascript
// src/app/entry/app.js

import Vuetify from 'vuetify';
Vue.use(Vuetify);

import 'vuetify/dist/vuetify.min.css' // Ensure you are using css-loader
```

#### 3. アイコンを使う設定

```html
<!-- google material icons -->
<link href='https://fonts.googleapis.com/css?family=Roboto:300,400,500,700|Material+Icons' rel="stylesheet">
<!-- fontawesome -->
<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.1.0/css/all.css" integrity="sha384-lKuwvrZot6UHsBSfcMvOkWwlCMgc0TaWr+30HWe3a4ltaBwTZhyTEggF5tJv8tbt" crossorigin="anonymous">
```

#### 4. あとはよしなに